### PR TITLE
add RIO timed run counts to group tooltip

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -564,6 +564,20 @@ function LFMPlus:SearchEntry_OnEnter(s)
     else
       GameTooltip_AddNormalLine(GameTooltip, DUNGEON_SCORE_DUNGEON_RATING_OVERTIME:format(leaderDungeonScoreInfo.mapName, color:WrapTextInColorCode(leaderDungeonScoreInfo.mapScore), leaderDungeonScoreInfo.bestRunLevel))
     end
+    if RaiderIO then
+      local playerProfile = RaiderIO.GetProfile("player")
+      local leaderProfile = nil
+      if playerProfile then
+        leaderProfile = RaiderIO.GetProfile(info.leaderName, playerProfile.faction)
+      end
+      if leaderProfile then
+        local leaderMilestones = leaderProfile.mythicKeystoneProfile.sortedMilestones
+        for _, milestone in ipairs(leaderMilestones) do
+          GameTooltip_AddNormalLine(GameTooltip, string.format("%s: %s", milestone.label, HIGHLIGHT_FONT_COLOR:WrapTextInColorCode(milestone.text)))
+        end
+      end
+    end
+  end
   end
   if info.age > 0 then
     GameTooltip:AddLine(string.format(LFG_LIST_TOOLTIP_AGE, SecondsToTime(info.age, false, false, 1, false)))

--- a/core.lua
+++ b/core.lua
@@ -571,8 +571,7 @@ function LFMPlus:SearchEntry_OnEnter(s)
         leaderProfile = RaiderIO.GetProfile(info.leaderName, playerProfile.faction)
       end
       if leaderProfile then
-        local leaderMilestones = leaderProfile.mythicKeystoneProfile.sortedMilestones
-        for _, milestone in ipairs(leaderMilestones) do
+        for _, milestone in ipairs(leaderProfile.mythicKeystoneProfile.sortedMilestones or {}) do
           GameTooltip_AddNormalLine(GameTooltip, string.format("%s: %s", milestone.label, HIGHLIGHT_FONT_COLOR:WrapTextInColorCode(milestone.text)))
         end
       end

--- a/core.lua
+++ b/core.lua
@@ -578,7 +578,6 @@ function LFMPlus:SearchEntry_OnEnter(s)
       end
     end
   end
-  end
   if info.age > 0 then
     GameTooltip:AddLine(string.format(LFG_LIST_TOOLTIP_AGE, SecondsToTime(info.age, false, false, 1, false)))
   end


### PR DESCRIPTION
Adds leader's timed dungeon run counts to the group tooltip if RaiderIO is present

![image](https://user-images.githubusercontent.com/2967926/147693324-c4d9e012-a82f-4897-a8b5-1903f24cbd57.png)
